### PR TITLE
chore: Config changes to prevent "Too many levels of nesting to fake this schema" errors

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -42,6 +42,7 @@ jobs:
           git commit -a -m "feat(postman): Update collection"
 
       - name: Push changes
+        if: ${{ github.event_name != 'pull_request' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -76,7 +76,7 @@ const EVENT = [
 
 Converter.convert(
   { type: "string", data: openapi, },
-  { folderStrategy: "Tags", alwaysInheritAuthentication: true, enableOptionalParameters: false, exampleParametersResolution: "Schema" },
+  { folderStrategy: "Tags", alwaysInheritAuthentication: true, enableOptionalParameters: false, exampleParametersResolution: "Schema", optimizeConversion: false, stackLimit: 50 },
   (_, conversionResult) => {
     if (!conversionResult.result) {
       console.log("Could not convert", conversionResult.reason);


### PR DESCRIPTION
We're getting these errors in the Postman schema:

<img width="665" height="365" alt="Screenshot 2026-02-17 at 15 30 16" src="https://github.com/user-attachments/assets/f55a9d30-e1c8-4e66-baa5-4bca9504ee97" />

Following [this recommendation](https://github.com/postmanlabs/openapi-to-postman/issues/306#issuecomment-901946755), I've added the `optimizeConversion: false, stackLimit: 50` config options to prevent these errors.

Below is a sample diff:
<img width="1511" height="356" alt="Screenshot 2026-02-17 at 15 31 16" src="https://github.com/user-attachments/assets/b721f72e-c87a-4364-8ff1-7f9285537058" />
